### PR TITLE
Misc Fixes

### DIFF
--- a/git-backport-diff
+++ b/git-backport-diff
@@ -231,7 +231,7 @@ compare_git()
         # subject lines, and using the last one.  Not all backports contain
         # the phrase "cherry-pick", so we can't really try and find the
         # upstream hash from that...
-        uphash=`git log $upstream --pretty=format:"%H" --fixed-strings --grep="${subj}" |tail -n 1`
+        uphash=`git log $upstream --pretty="%H %s" | grep -F "${subj}" | tail -n 1 | awk '{print $1}'`
         if [[ -n "$uphash" ]]
         then
             numdiff=`diff -u <(git diff $uphash^!   |egrep ^[-+])\

--- a/git-backport-diff
+++ b/git-backport-diff
@@ -36,7 +36,7 @@ Ouput key:
 [####]   Indicates the number of differences (#### is substituted)
 [down]   Indicates the patch only exists downstream"
 
-def_upstream="v1.7.0"
+def_upstream="@{upstream}"
 def_diffprog=meld
 def_range="HEAD^!"
 def_color='y'


### PR DESCRIPTION
Hi jtc! Two misc fixes.

(1) Change the default upstream to the actual git symbolic link for upstreams
(2) Change the grep magic to be a little choosier.