### PR TITLE
git-backport-diff: Default to newest commit

### DIFF
--- a/git-backport-diff
+++ b/git-backport-diff
@@ -228,10 +228,19 @@ compare_git()
         subj=${hashsubj:40}
         downhash=${hashsubj:0:40}
         # A little bit hackish, but find the match by looking at upstream
-        # subject lines, and using the last one.  Not all backports contain
+        # subject lines, and using the newest one.  Not all backports contain
         # the phrase "cherry-pick", so we can't really try and find the
         # upstream hash from that...
-        uphash=`git log $upstream --pretty=format:"%H" --fixed-strings --grep="${subj}" |tail -n 1`
+        uphash=""
+        while read uphashsubj
+        do
+            if [[ "${uphashsubj:40}" == "$subj" ]]
+            then
+                uphash=${uphashsubj:0:40}
+                break
+            fi
+        done < <(git log $upstream --pretty=tformat:"%H%s" --fixed-strings --grep="${subj}")
+
         if [[ -n "$uphash" ]]
         then
             numdiff=`diff -u <(git diff $uphash^!   |egrep ^[-+])\


### PR DESCRIPTION
It is more likely that a backport refers to a newer commit than to an
old one.  One reason not to do so is because a later commit may
reference the existing commit in its message.  To get around this, only
look at commits that actually have a matching subject and ignore their
message body.

As a side effect, this generally makes the script faster because the
git-log process is quit once the first valid match is found.